### PR TITLE
Fix an issue with sui-slider CSS

### DIFF
--- a/src/components/sui-slider.vue
+++ b/src/components/sui-slider.vue
@@ -328,10 +328,6 @@ export default {
     margin: 0;
 }
 
-.wrapper {
-    width: 800px;
-}
-
 .slide-item {
     position: relative;
     display: inline-block;


### PR DESCRIPTION
Removed unused class which causes all wrapper class to have width of 800px